### PR TITLE
Try installing requirements.txt in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
 
     - run: python -m pip install -U pip build
 
+    - run: python -m pip install -r requirements.txt
+
     - run: python -m build
 
     - uses: mpi4py/setup-mpi@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - uses: mpi4py/setup-mpi@v1
+      with:
+        mpi: ${{ matrix.mpi }}
+
     - run: |
         # Install fftw
         case $(uname) in
@@ -53,9 +57,5 @@ jobs:
     - run: python -m pip install -r requirements.txt
 
     - run: python -m build
-
-    - uses: mpi4py/setup-mpi@v1
-      with:
-        mpi: ${{ matrix.mpi }}
 
     - run: pip install -vvv dist/mpi4py_fft-*.whl

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,6 @@ if __name__ == '__main__':
           distclass=Dist,
           ext_modules=get_extensions(),
           install_requires=["mpi4py", "numpy"],
-          setup_requires=["setuptools>=18.0", "cython>=0.25"],
+          setup_requires=["setuptools>=18.0", "cython>=0.25", "numpy"],
           keywords=['Python', 'FFTW', 'FFT', 'DCT', 'DST', 'MPI']
          )


### PR DESCRIPTION
Try to fix the following error during the wheel build step of the CI workflow undergoing an update in https://github.com/mpi4py/mpi4py-fft/pull/30.
```
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for sdist...
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 287, in get_requires_for_build_sdist
    return hook(config_settings)
  File "/tmp/build-env-lf1dau7p/lib/python3.10/site-packages/setuptools/build_meta.py", line 328, in get_requires_for_build_sdist
    return self._get_build_requires(config_settings, requirements=[])
  File "/tmp/build-env-lf1dau7p/lib/python3.10/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-lf1dau7p/lib/python3.10/site-packages/setuptools/build_meta.py", line 487, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/tmp/build-env-lf1dau7p/lib/python3.10/site-packages/setuptools/build_meta.py", line 311, in run_setup
    exec(code, locals())
  File "<string>", line [12](https://github.com/benlandrum/mpi4py-fft/actions/runs/8491772884/job/23264065777#step:6:13), in <module>
ModuleNotFoundError: No module named 'numpy'
```