### PR TITLE
Simplify workflow OS switch

### DIFF
--- a/.github/actions/setup-fftw/action.yml
+++ b/.github/actions/setup-fftw/action.yml
@@ -4,7 +4,7 @@ description: "Set up FFTW."
 author: "Ben Landrum"
 inputs:
   os:
-    description: "Operating system name (e.g., ubuntu-latest)."
+    description: "Hyphenated operating system name, e.g., ubuntu-latest."
 outputs:
   include-dir:
     description: "The installed FFTW include directory."

--- a/.github/actions/setup-fftw/setup-fftw.sh
+++ b/.github/actions/setup-fftw/setup-fftw.sh
@@ -4,44 +4,37 @@
 # ubuntu-latest -> ubuntu
 os=${1%-*}
 
-setup-apt-fftw () {
-    sudo apt update && sudo apt install -y -q libfftw3-dev
-}
-
-setup-brew-fftw () {
+install-package-macos () {
     brew install fftw
 }
 
-setup-env-fftw () {
-    case "$os" in
-	macos)
-	    prefix=$(brew --prefix fftw)
-	    echo "include-dir=$prefix/include" >> "$GITHUB_OUTPUT"
-	    echo "library-dir=$prefix/lib" >> "$GITHUB_OUTPUT"
-	    ;;
-	ubuntu)
-	    echo "include-dir=/usr/include" >> "$GITHUB_OUTPUT"
-	    echo "library-dir=/usr/lib/x86_64-linux-gnu" \
-		 >> "$GITHUB_OUTPUT"
-	    ;;
-	*)
-	    echo os "$os" not recognized
-	    exit 1
-	    ;;
-    esac
+install-package-ubuntu () {
+    sudo apt update && sudo apt install -y -q libfftw3-dev
 }
 
-case $(uname) in
-    Linux)
-	setup-apt-fftw
+setup-env-ubuntu() {
+    echo "include-dir=/usr/include" >> "$GITHUB_OUTPUT"
+    echo "library-dir=/usr/lib/x86_64-linux-gnu" \
+	 >> "$GITHUB_OUTPUT"
+}
+
+setup-env-macos() {
+    local prefix=$(brew --prefix fftw)
+    echo "include-dir=$prefix/include" >> "$GITHUB_OUTPUT"
+    echo "library-dir=$prefix/lib" >> "$GITHUB_OUTPUT"
+}
+
+case "$os" in
+    macos)
+	install-package-macos
+	setup-env-macos
 	;;
-    Darwin)
-	setup-brew-fftw
+    ubuntu)
+	install-package-ubuntu
+	setup-env-ubuntu
 	;;
     *)
-	echo uname $(uname) not recognized
+	echo os "$os" not recognized
 	exit 1
 	;;
 esac
-
-setup-env-fftw


### PR DESCRIPTION
Avoid checking twice for the operating system. Set naming expectations in the operating system input parameter.